### PR TITLE
Add spotless for consistent license headers in .kt files

### DIFF
--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,18 @@
+/*
+ * StickySurvival - an implementation of the Survival Games minigame
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
     id("eclipse")
 
     id("net.nemerosa.versioning") version "2.14.0"
+
+    id("com.diffplug.spotless") version "5.12.1"
 }
 
 group = "com.dumbdogdiner"
@@ -59,6 +61,7 @@ dependencies {
 tasks {
     ktlintKotlinScriptCheck {
         dependsOn("ktlintFormat")
+        dependsOn("spotlessApply")
     }
 
     compileKotlin {
@@ -73,6 +76,13 @@ tasks {
 
     shadowJar {
         archiveClassifier.set("")
+    }
+
+    configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+        encoding("UTF-8") // all formats will be interpreted as UTF-8
+        kotlin {
+            licenseHeaderFile(project.file("LICENSE_HEADER"))
+        }
     }
 
     spigot {

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/Game.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/Game.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/LobbyHologram.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/LobbyHologram.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/StickySurvival.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/StickySurvival.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/StickySurvivalExpansion.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/StickySurvivalExpansion.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/command/Misc.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/command/Misc.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/command/SGCommand.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/command/SGCommand.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/Config.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/Config.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/ConfigHelper.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/ConfigHelper.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/InvalidConfigException.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/InvalidConfigException.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/KitConfig.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/KitConfig.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/LootConfig.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/LootConfig.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/MessageConfig.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/MessageConfig.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/WorldBound.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/WorldBound.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/WorldConfig.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/WorldConfig.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/BossBarMessages.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/BossBarMessages.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/ChatMessages.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/ChatMessages.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/LobbyMessages.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/LobbyMessages.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/TitleMessages.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/config/language/TitleMessages.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeAddEvent.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeAddEvent.kt
@@ -1,3 +1,21 @@
+/*
+ * StickySurvival - an implementation of the Survival Games minigame
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.dumbdogdiner.stickysurvival.event
 
 import org.bukkit.entity.Player

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeRemoveEvent.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeRemoveEvent.kt
@@ -1,3 +1,21 @@
+/*
+ * StickySurvival - an implementation of the Survival Games minigame
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.dumbdogdiner.stickysurvival.event
 
 import com.dumbdogdiner.stickysurvival.Game

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeWinEvent.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeWinEvent.kt
@@ -1,3 +1,21 @@
+/*
+ * StickySurvival - an implementation of the Survival Games minigame
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.dumbdogdiner.stickysurvival.event
 
 import org.bukkit.entity.Player

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeWinRewardEvent.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/event/TributeWinRewardEvent.kt
@@ -1,3 +1,21 @@
+/*
+ * StickySurvival - an implementation of the Survival Games minigame
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.dumbdogdiner.stickysurvival.event
 
 import com.dumbdogdiner.stickysurvival.Game

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/FasterWorldLoadsListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/FasterWorldLoadsListener.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/GameEventsListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/GameEventsListener.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/LobbyHologramListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/LobbyHologramListener.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/PerWorldChatListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/PerWorldChatListener.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/PlayerJoinAndLeaveListener.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/listener/PlayerJoinAndLeaveListener.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/AnimatedScoreboardManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/AnimatedScoreboardManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/HiddenPlayerManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/HiddenPlayerManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/LobbyInventoryManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/LobbyInventoryManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/PlayerNameManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/PlayerNameManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/StatsManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/StatsManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/WorldManager.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/manager/WorldManager.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/stats/PlayerStats.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/stats/PlayerStats.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/AutoQuitRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/AutoQuitRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/ChestRefillRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/ChestRefillRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/RandomDropRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/RandomDropRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/SafeRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/SafeRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/TimerRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/TimerRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/TrackingCompassRunnable.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/task/TrackingCompassRunnable.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/Logging.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/Logging.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/Misc.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/Misc.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/PlayerExtensions.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/PlayerExtensions.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/WorldExtensions.kt
+++ b/src/main/kotlin/com/dumbdogdiner/stickysurvival/util/WorldExtensions.kt
@@ -1,6 +1,6 @@
 /*
  * StickySurvival - an implementation of the Survival Games minigame
- * Copyright (C) 2020 Dumb Dog Diner <dumbdogdiner.com>
+ * Copyright (C) 2021 Dumb Dog Diner <dumbdogdiner.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Something to note here is that quite a lot of files were edited by `spotlessApply`, mostly to update the copyright year. If this is an issue then we could configure spotless to only lint newly-changed files if cluttering up our git history is a concern.